### PR TITLE
通知機能のアップデート

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace App\Http\Controllers;
-use App\Models\notification;
+use App\Models\Notification;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Http\Request;
 
@@ -13,7 +13,8 @@ class NotificationController extends Controller
         $latestNotification = Notification::latest('created_at')->first(); // 最新の通知を取得
         $formattedNotification = [
             'title' => $latestNotification->title,
-            'created_at' => $latestNotification->created_at
+            'created_at' => $latestNotification->created_at,
+            'url' => $latestNotification->url
         ];
 
         Log::info($formattedNotification); // ログに最新の通知を記録

--- a/app/Http/Controllers/QuestionController.php
+++ b/app/Http/Controllers/QuestionController.php
@@ -61,9 +61,18 @@ class QuestionController extends Controller
         $reply->reply_content = $request->reply_content;
         $reply->save();
 
-        //正常にデータが挿入されたら、通知を作成
-        $notification = new Notification();
-        $notification->title = '質問に回答がありました。';
+        // 質問オブジェクトを取得
+        $question = CompanyQuestion::findOrFail($request->question_id);
+
+         // 質問への URL を生成
+        $questionUrl = $this->generateQuestionUrl($question->company_id, $question->id);
+
+
+        // URL を通知に直接追加し、データベースに保存
+        $notification = new Notification([
+            'title' => '質問に回答がありました。',
+            'url' => $questionUrl,
+        ]);
         $notification->save();
 
         return redirect()->back()->with('success', '返信が投稿されました。');
@@ -94,7 +103,7 @@ class QuestionController extends Controller
 
         //正常にデータが挿入されたら、通知を作成
         $notification = new Notification();
-        $notification->title = '質問が投稿されました。';
+        $notification->title = $company->company_name .'に質問が投稿されました。';
         $notification->save();
 
         return redirect()->route('company.questions', ['companyId' => $company->id])->with('success', '質問が投稿されました。');
@@ -114,5 +123,12 @@ class QuestionController extends Controller
         $replies = CompanyQuestionReply::where('company_question_id', $questionId)->get();
 
         return view('jobs.question', compact('company', 'question', 'replies'));
+    }
+    /**
+     * これはURLを作成するやつ
+     */
+    protected function generateQuestionUrl($companyId, $questionId)
+    {
+        return url("/companies/{$companyId}/questions/{$questionId}");
     }
 }

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -12,6 +12,9 @@ class notification extends Model
     protected $table = 'notification';
 
     protected $fillable = [
-        'title',//通知用タイトル
+        'title',//通知用タイトル// Notification.php
+        'url',//通知用URL// Notification.php
+        'created_at',
+        'updated_at'
     ];
 }

--- a/database/migrations/2023_11_14_095041_create_notification_table.php
+++ b/database/migrations/2023_11_14_095041_create_notification_table.php
@@ -16,6 +16,7 @@ class CreateNotificationTable extends Migration
         Schema::create('notification', function (Blueprint $table) {
             $table->id();
             $table->string('title', 100);
+            $table->string('url')->nullable()->default(null);
             $table->timestamps();
         });
     }

--- a/public/css/notification.css
+++ b/public/css/notification.css
@@ -32,3 +32,34 @@ li.notification {
     color: #777;
 }
 
+/* モーダル部分のデザイン（通知用）*/
+#notificationList {
+    list-style-type: none;
+    padding: 0;
+}
+
+.notification-item {
+    border: 1px solid #ccc;
+    margin-bottom: 10px;
+    padding: 10px;
+    border-radius: 5px;
+}
+
+.notification-item h5 {
+    margin-bottom: 5px;
+}
+
+/* 通知のスタイル */
+.notification-item {
+    margin-bottom: 10px;
+}
+
+/* リンクのスタイル */
+.notification-item a {
+    color: dodgerblue;
+    text-decoration: underline;
+}
+
+/* 他のスタイルやアニメーションを追加できます */
+
+

--- a/resources/views/header.blade.php
+++ b/resources/views/header.blade.php
@@ -60,8 +60,8 @@
 </nav>
 
 <script>
-    // モーダルが表示された時の処理
-    $('#notificationModal').on('show.bs.modal', function () {
+// モーダルが表示された時の処理
+$('#notificationModal').on('show.bs.modal', function () {
     $.ajax({
         url: "{{ route('notifications.fetch') }}",
         method: 'GET',
@@ -70,8 +70,22 @@
             notificationList.empty(); // 通知リストをクリア
 
             if (data.title) {
-                notificationList.append('<li>' + data.title + '</li>'); // 最新の通知を表示
-                notificationList.append('<li>Created At: ' + data.created_at + '</li>'); // Created Atを表示
+                // created_atをDateオブジェクトに変換
+                var createdAtDate = new Date(data.created_at);
+                // 表示用のフォーマットに変換
+                var formattedCreatedAt = createdAtDate.toLocaleString();
+
+                var notificationItem = $('<div class="notification-item">');
+                notificationItem.append('<h5>' + data.title + '</h5>');
+                notificationItem.append('<p>作成日: ' + formattedCreatedAt + '</p>');
+
+                // data.urlが存在する場合、リンクを生成
+                if (data.url) {
+                    var link = $('<a>').attr('href', data.url).text('詳細を見る');
+                    notificationItem.append(link);
+                }
+
+                notificationList.append(notificationItem);
             } else {
                 notificationList.append('<p>通知はありません。</p>');
             }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -9,12 +9,13 @@
     <title>@yield('title')</title>
 
     <link rel="stylesheet" href="{{ asset('css/app.css') }}">
-    
+    <link rel="stylesheet" href="{{ asset('css/notification.css') }}">
+
     <!-- ビューファイル内の<head>セクション内に以下のスクリプトを追加 -->
     <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
-    
+
     <!-- Optional JavaScript -->
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>


### PR DESCRIPTION
質問に回答が投稿された時に通知画面にそのページに飛ぶためのURLを埋め込むように改良しました。
改良前ー＞「回答が投稿されました。」
改良後ー＞「回答が投稿されました。」
　　　　　「作成日：2023/11/1 12:00:00」
　　　　　「詳細を見る（埋め込みURL）」


また、新しい質問が投稿された場合に新たに企業名をつけた通知文に改良しました。
改良前ー＞「質問が投稿されました。」
改良後ー＞「〇〇（企業名）に質問が投稿されました。」
